### PR TITLE
Command Line Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,4 +139,5 @@ resume.pdf
 /data/anonymous.yaml
 /data/trung.yaml
 *.pdf
-cv.yaml
+anshul_cv.yaml
+anshul_cv_csv

--- a/main.py
+++ b/main.py
@@ -23,12 +23,12 @@ my_parser.add_argument('--input', '-i', nargs='*', action='store', type=str, req
                         default='./data/data.yaml', help='Input data file(s), either CSV files or a YAML file')
 my_parser.add_argument('--output', '-o', action='store', type=str, required=True, help='Output file name')
 my_parser.add_argument('--key', '-k', action='store', nargs='+', type=str, required=True, help='Skill keys to filter for')
-my_parser.add_argument('--max_experience', '-me', type= int, required=False, default=7, help='Maximum experience')
-my_parser.add_argument('--max_skills', '-ms', type =int, required=False, default=7, help='Maximum skills shown in tab')
-my_parser.add_argument('--display_project_skills', '-dps', action='store_true', help='Show skills in job section')
-my_parser.add_argument('--header_font_size', '-hs', type=float, required=False, default=12, help='Set header font size')
-my_parser.add_argument('--body_font_size', '-bs', type=float, required=False, default=10.5, help='Set body font size')
-my_parser.add_argument('--title_font_size', '-ts', type=float, required=False, default=20, help='Set title font size')
+my_parser.add_argument('--max-experience', '-me', type= int, required=False, default=7, help='Maximum experience')
+my_parser.add_argument('--max-skills', '-ms', type =int, required=False, default=7, help='Maximum skills shown in tab')
+my_parser.add_argument('--display-project-skills', '-dps', action='store_true', help='Show skills in job section')
+my_parser.add_argument('--header-font-size', '-hs', type=float, required=False, default=12, help='Set header font size')
+my_parser.add_argument('--body-font-size', '-bs', type=float, required=False, default=10.5, help='Set body font size')
+my_parser.add_argument('--title-font-size', '-ts', type=float, required=False, default=20, help='Set title font size')
 my_parser.add_argument('--debug', '-d', action='store_true', help='Print debug logging')
 
 # Parsed args

--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ my_parser.add_argument('--output', '-o', action='store', type=str, required=True
 my_parser.add_argument('--key', '-k', action='store', nargs='+', type=str, required=True, help='Skill keys to filter for')
 my_parser.add_argument('--max_experience', '-me', type= int, required=False, default=7, help='Maximum experience')
 my_parser.add_argument('--max_skills', '-ms', type =int, required=False, default=7, help='Maximum skills shown in tab')
-my_parser.add_argument('--display_project_skills', '-dps', type=Boolean, required=False, default=False, help='Show skills in job section')
+my_parser.add_argument('--display_project_skills', '-dps', action='store_true', help='Show skills in job section')
 my_parser.add_argument('--header_font_size', '-hs', type=float, required=False, default=12, help='Set header font size')
 my_parser.add_argument('--body_font_size', '-bs', type=float, required=False, default=10.5, help='Set body font size')
 my_parser.add_argument('--title_font_size', '-ts', type=float, required=False, default=20, help='Set title font size')

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ import sys
 my_parser = argparse.ArgumentParser(description='Resume Generator based off Key')
 my_parser.add_argument('--input', '-i', nargs='*', action='store', type=str, required=False, 
                         default='./data/data.yaml', help='Input data file(s), either CSV files or a YAML file')
-my_parser.add_argument('--fname', '-f', action='store', type=str, required=True, help='Output file name')
+my_parser.add_argument('--output', '-o', action='store', type=str, required=True, help='Output file name')
 my_parser.add_argument('--key', '-k', action='store', nargs='+', type=str, required=True, help='Skill keys to filter for')
 my_parser.add_argument('--max_experience', '-me', type= int, required=False, default=7, help='Maximum experience')
 my_parser.add_argument('--max_skills', '-ms', type =int, required=False, default=7, help='Maximum skills shown in tab')
@@ -38,7 +38,7 @@ input = args['input']
 me = args['max_experience']
 ms = args['max_skills']
 dps = args['display_project_skills']
-fname = args['fname']
+output = args['output']
 key = args['key']
 header_font_size = args['header_font_size']
 body_font_size = args['body_font_size']
@@ -54,16 +54,16 @@ logger.info('Input file(s): %s', input)
 logger.info('Max experience: %s', me)
 logger.info('Max skills: %s', ms)
 logger.info('Display project skills: %s', dps)
-logger.info('Output file: %s', fname)
+logger.info('Output file: %s', output)
 logger.info('Skill keys: %s', key)
 logger.info('Header font size: %s', header_font_size)
 logger.info('Body font size: %s', body_font_size)
 logger.info('Title font size: %s', title_font_size)
 
 # Append default extension
-if not fname.endswith('.pdf'):
-   fname = fname + '.pdf'
-   logger.debug('Updated output filename with ext: %s', fname)
+if not output.endswith('.pdf'):
+   output = output + '.pdf'
+   logger.debug('Updated output filename with ext: %s', output)
 
 # Create resume
 resume = None
@@ -87,7 +87,7 @@ else:
          logger.error('Expecting either basic_info.csv, experience.csv, or skills.csv, got %s', file)
          sys.exit(1)
    resume = builder_from_csv(job_csv, skills_csv, basic_csv)
-resume.build_resume(template, key, fname,
+resume.build_resume(template, key, output,
    max_experience=me, 
    max_skills=ms, 
    display_project_skills=dps, 

--- a/main.py
+++ b/main.py
@@ -18,11 +18,12 @@ import logging
 import sys
 
 # Argument parser
-my_parser = argparse.ArgumentParser(description='Resume Generator based off Key')
+my_parser = argparse.ArgumentParser(description='Generate a resume. Filter experience based on input tags')
+my_parser.add_argument('--tags', '-t', metavar='TAG', action='store', nargs='+', type=str, 
+                        required=True, help='Tags to filter for')
 my_parser.add_argument('--input', '-i', nargs='*', action='store', type=str, required=False, 
                         default='./data/data.yaml', help='Input data file(s), either CSV files or a YAML file')
 my_parser.add_argument('--output', '-o', action='store', type=str, required=True, help='Output file name')
-my_parser.add_argument('--key', '-k', action='store', nargs='+', type=str, required=True, help='Skill keys to filter for')
 my_parser.add_argument('--max-experience', '-me', type= int, required=False, default=7, help='Maximum experience')
 my_parser.add_argument('--max-skills', '-ms', type =int, required=False, default=7, help='Maximum skills shown in tab')
 my_parser.add_argument('--display-project-skills', '-dps', action='store_true', help='Show skills in job section')
@@ -34,12 +35,12 @@ my_parser.add_argument('--debug', '-d', action='store_true', help='Print debug l
 # Parsed args
 args = vars(my_parser.parse_args())
 template = template_basic()
+tags = args['tags']
 input = args['input']
-me = args['max_experience']
-ms = args['max_skills']
-dps = args['display_project_skills']
 output = args['output']
-key = args['key']
+max_experience = args['max_experience']
+max_skills = args['max_skills']
+display_project_skills = args['display_project_skills']
 header_font_size = args['header_font_size']
 body_font_size = args['body_font_size']
 title_font_size = args['title_font_size']
@@ -51,11 +52,11 @@ logger = logging.getLogger('main')
 
 # Log input variables
 logger.info('Input file(s): %s', input)
-logger.info('Max experience: %s', me)
-logger.info('Max skills: %s', ms)
-logger.info('Display project skills: %s', dps)
+logger.info('Max experience: %s', max_experience)
+logger.info('Max skills: %s', max_skills)
+logger.info('Display project skills: %s', display_project_skills)
 logger.info('Output file: %s', output)
-logger.info('Skill keys: %s', key)
+logger.info('Skill tags: %s', tags)
 logger.info('Header font size: %s', header_font_size)
 logger.info('Body font size: %s', body_font_size)
 logger.info('Title font size: %s', title_font_size)
@@ -87,10 +88,10 @@ else:
          logger.error('Expecting either basic_info.csv, experience.csv, or skills.csv, got %s', file)
          sys.exit(1)
    resume = builder_from_csv(job_csv, skills_csv, basic_csv)
-resume.build_resume(template, key, output,
-   max_experience=me, 
-   max_skills=ms, 
-   display_project_skills=dps, 
+resume.build_resume(template, tags, output,
+   max_experience=max_experience, 
+   max_skills=max_skills, 
+   display_project_skills=display_project_skills, 
    header_font_size=header_font_size, 
    body_font_size=body_font_size, 
    title_font_size=title_font_size)

--- a/resume_builder/builder.py
+++ b/resume_builder/builder.py
@@ -154,20 +154,12 @@ def builder_from_csv(fjobs, fskills, basic_info):
     jobs['type'] = jobs['type'].apply(lambda x: x.upper())
     basic = pd.read_csv(basic_info)
     basic.edu_1 = basic.edu_1.apply(lambda x:str(x).split('/ '))
-    basic.edu_2 = basic.edu_2.apply(lambda x:str(x).split('/ '))
     education = {
-        basic.edu_1.item()[0] : 
+        basic.edu_1.item()[0]: 
         {
             'address':basic.edu_1.item()[1], 
             'completed': basic.edu_1.item()[2],
             'GPA': basic.edu_1.item()[3]
-
-        },
-        basic.edu_2.item()[0] : 
-        {
-            'address': basic.edu_2.item()[1],
-            'completed': basic.edu_2.item()[2],
-            'GPA': basic.edu_2.item()[3]
         }
     }
     address = basic.address.item()


### PR DESCRIPTION
So I did a couple things

Rename `fname` option to output

Change `--display-project-skills` to be a flag, so that you only need to write `--display-project-skills` instead of `--display-project-skills True`

Also I changed the underscores (`_`) in the options to dashes (`-`).

For CSV files: I have the command line input option require a directory where the files are stored, rather than writing multiple input files (which will have to have the same names anyway)

e.g. I have my csv files in `resume_dir/` which contains a `basic_info.csv`, a `skills.csv`, and an `experience.csv`

    > py main.py --input resume_dir ...